### PR TITLE
Fix/normalize

### DIFF
--- a/src/Concerns/CanNormalize.php
+++ b/src/Concerns/CanNormalize.php
@@ -16,6 +16,6 @@ trait CanNormalize
             throw new InvalidMyanmarPhoneNumber('Invalid myanmar phone number!');
         }
 
-        return preg_replace('/^\+?959|09/', $prefix, $phone);
+        return preg_replace('/^(?:\+?959|09)/', $prefix, $phone);
     }
 }

--- a/src/Exceptions/InvalidMyanmarPhoneNumber.php
+++ b/src/Exceptions/InvalidMyanmarPhoneNumber.php
@@ -4,6 +4,4 @@ namespace LaravelMyanmarTools\PhoneNumber\Exceptions;
 
 use Exception;
 
-class InvalidMyanmarPhoneNumber extends Exception
-{
-}
+class InvalidMyanmarPhoneNumber extends Exception {}

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -21,20 +21,20 @@ use Spatie\Macroable\Macroable;
 
 class PhoneNumber
 {
-    use CanCheckMyanmarPhoneNumber;
+    use CanCheckMec;
     use CanCheckMpt;
+    use CanCheckMyanmarPhoneNumber;
+    use CanCheckMytel;
     use CanCheckOoredoo;
     use CanCheckTelenor;
-    use CanCheckMec;
-    use CanCheckMytel;
+    use CanExtractMec;
+    use CanExtractMpt;
+    use CanExtractMyanmarPhoneNumber;
+    use CanExtractMytel;
+    use CanExtractOoredoo;
+    use CanExtractTelenor;
     use CanGetNetworkType;
     use CanGetTelecomName;
     use CanNormalize;
-    use CanExtractMyanmarPhoneNumber;
-    use CanExtractMpt;
-    use CanExtractOoredoo;
-    use CanExtractTelenor;
-    use CanExtractMec;
-    use CanExtractMytel;
     use Macroable;
 }

--- a/src/Services/NormalizerService.php
+++ b/src/Services/NormalizerService.php
@@ -6,8 +6,7 @@ class NormalizerService
 {
     public function __construct(
         public string $str
-    ) {
-    }
+    ) {}
 
     public function normalize(): string
     {

--- a/src/Services/RegexService.php
+++ b/src/Services/RegexService.php
@@ -9,8 +9,7 @@ class RegexService
 {
     public function __construct(
         public string $str
-    ) {
-    }
+    ) {}
 
     public function isMyanmarPhoneNumber(): bool
     {


### PR DESCRIPTION
This pull request primarily refactors the codebase to improve consistency, streamline class definitions, and enhance the normalization logic for Myanmar phone numbers. The changes include reordering and regrouping trait usage in the `PhoneNumber` class, simplifying class and constructor definitions, and making a minor but important fix to the phone number normalization regex.

Trait reordering and regrouping:

* Reordered and regrouped trait usage in the `PhoneNumber` class to ensure logical grouping and maintainability. Traits related to checking, extracting, and utility functions are now grouped together for clarity. (`src/PhoneNumber.php`)

Code simplification:

* Converted single-method class bodies to single-line definitions for brevity in `InvalidMyanmarPhoneNumber`, `NormalizerService`, and `RegexService`. (`src/Exceptions/InvalidMyanmarPhoneNumber.php`, `src/Services/NormalizerService.php`, `src/Services/RegexService.php`) [[1]](diffhunk://#diff-c2d1195b409839cf49bd8bf2b11aae4be88c87613eaf768b4179a966695ffe7dL7-R7) [[2]](diffhunk://#diff-fd7d8ad9aaeac00fe76cc4844fd64d977c8be60513eb6c29b43c487b3df61cdaL9-R9) [[3]](diffhunk://#diff-ef6babf218e3824e64f51bffbdd6ad25fad4d049106b485c1cf45c1562794badL12-R12)

Normalization logic fix:

* Updated the regular expression in the `normalize` method to use a non-capturing group, ensuring correct replacement of Myanmar phone number prefixes. (`src/Concerns/CanNormalize.php`)